### PR TITLE
Don't pass an argument to item.task() - it will only be ignored

### DIFF
--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -25,7 +25,7 @@ module.exports = function(capacity) {
 			}
 
 			semaphore.current += item.n;
-			item.task(semaphore.leave);
+			item.task();
 		},
 
 		leave: function(n) {


### PR DESCRIPTION
Like this?

It's the same as the patch in my original issue.
