### PR TITLE
removed unused utils & converted splice to shift

### DIFF
--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -1,5 +1,3 @@
-var util = require('util');
-
 module.exports = function(capacity) {
 	var semaphore = {
 		capacity: capacity || 1,
@@ -47,7 +45,7 @@ module.exports = function(capacity) {
 				return;
 			}
 
-			semaphore.queue = semaphore.queue.splice(1);
+			semaphore.shift();
 			semaphore.current += item.n;
 
 			process.nextTick(item.task);


### PR DESCRIPTION
using splice copies the whole array to a new array. So using splice is tiny bit more efficient. 