### PR TITLE
Increasing of reliability

### DIFF
--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -5,8 +5,16 @@ module.exports = function(capacity) {
 		capacity: capacity || 1,
 		current: 0,
 		queue: [],
+		firstHere: false,
 
 		take: function() {
+			if (semaphore.firstHere === false) {
+        			semaphore.current++;
+        			semaphore.firstHere = true;
+        			var isFirst = 1;
+      			} else {
+        			var isFirst = 0;
+      			}
 			var item = { n: 1 };
 
 			if (typeof arguments[0] == 'function') {
@@ -23,12 +31,14 @@ module.exports = function(capacity) {
 			var task = item.task;
 			item.task = function() { task(semaphore.leave); };
 
-			if (semaphore.current + item.n > semaphore.capacity) {
+			if (semaphore.current + item.n - isFirst > semaphore.capacity) {
+        			if (isFirst === 1) semaphore.firstHere = false;
 				return semaphore.queue.push(item);
 			}
 
-			semaphore.current += item.n;
+			semaphore.current += item.n - isFirst;
 			item.task(semaphore.leave);
+      			if (isFirst === 1) semaphore.firstHere = false;
 		},
 
 		leave: function(n) {

--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -32,7 +32,10 @@ module.exports = function(capacity) {
 			item.task = function() { task(semaphore.leave); };
 
 			if (semaphore.current + item.n - isFirst > semaphore.capacity) {
-        			if (isFirst === 1) semaphore.firstHere = false;
+        			if (isFirst === 1) {
+        				semaphore.current--;
+        				semaphore.firstHere = false;
+        			}
 				return semaphore.queue.push(item);
 			}
 


### PR DESCRIPTION
I've tested semaphore.js with 1000 of competing requests and found that old implementation may call item.task(semaphore.leave); from task() for several queries "in parallel" even if capacity was set to 1.
It happened because of increment of 'current' counter was launched after execution of some code like IFs checking and preparation of data before a 'current' counter checking.
Increment of 'current' counter should launched ASAP, when 'take' function is called. 
So, I implemented 'first request flag', which increments counter 'current' immediatelly for the first counter.

Still be careful to use semaphore.js with capacity more than one and high concurrency.
In general, semaphore is a bool trigger.