### PR TITLE
Semaphore Availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ sem.take(n, fn)
 
 // Leave
 sem.leave([n])
+
+// Available
+sem.available([n])
 ```
 
 

--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -75,6 +75,11 @@ function semaphore(capacity) {
 			semaphore.current += item.n;
 
 			nextTick(item.task);
+		},
+
+		available: function(n) {
+			n = n || 1;
+			return(semaphore.current + n <= semaphore.capacity);
 		}
 	};
 


### PR DESCRIPTION
Added the capability to check if a semaphore is available without taking it, can be useful in circumstances where logic needs to be based simply on availability of the semaphore.