### PR TITLE
Add license in package.json to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "mocha": "2.x.x",
     "should": "8.x.x"
   },
+  "license": "MIT",
   "homepage": "https://github.com/abrkn/semaphore.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Looks like it was the author's intention to license to MIT as per Readme but it's not as machine readable as in package.json